### PR TITLE
Update attack button text

### DIFF
--- a/components/CombatComponent.tsx
+++ b/components/CombatComponent.tsx
@@ -131,7 +131,7 @@ export function CombatComponent({
         disabled={playerHp <= 0 || enemyHp <= 0 || isRolling}
         className="w-full py-2 bg-red-600 hover:bg-red-500 active:translate-y-0.5 rounded-lg font-semibold text-white"
       >
-        공격 (d20+5, dmg d8+{strMod})
+        공격 {`(d20+5, dmg d8+${strMod})`}
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary
- show the current strength modifier when displaying the attack button

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68417ce9dd8083259716fa673740f7a4