### PR TITLE
Add Jest setup and test for CombatComponent

### DIFF
--- a/__tests__/CombatComponent.test.tsx
+++ b/__tests__/CombatComponent.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { act } from 'react-dom/test-utils';
+import { CombatComponent } from '../components/CombatComponent';
+
+describe('CombatComponent', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.spyOn(Math, 'random').mockReturnValue(0.99);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('renders attack button and calls onVictory when enemy HP reaches zero', () => {
+    const onVictory = jest.fn();
+    const onEnd = jest.fn();
+    const setPlayerHp = jest.fn();
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+
+    act(() => {
+      ReactDOM.createRoot(container).render(
+        <CombatComponent
+          playerHp={30}
+          setPlayerHp={setPlayerHp}
+          enemyLevel={0}
+          playerLevel={10}
+          buffStats={{ strength: 20 }}
+          onVictory={onVictory}
+          onEnd={onEnd}
+        />
+      );
+    });
+
+    const button = container.querySelector('button');
+    expect(button).not.toBeNull();
+
+    act(() => {
+      button!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(onVictory).toHaveBeenCalled();
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@google/genai": "^0.13.0",
@@ -27,6 +28,9 @@
     "eslint-config-next": "15.3.2",
     "postcss": "^8.5.3",
     "tailwindcss": "^4.1.5",
-    "typescript": "^5"
+    "typescript": "^5",
+    "@types/jest": "^29.5.11",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- add jest with TypeScript preset
- create a test checking CombatComponent victory logic
- include jest dev dependencies and npm test script

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68417ceedf8c8325a568032f4ed6f449