### PR TITLE
Integrate 5e‑srd data and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@
   d20 주사위 판정, 공격/방어 로직, 전투 UI, 승패에 따른 분기 처리.  
 - **위험도 기반 적 레벨 조정**  
   `low`/`medium`/`high` 위험도에 따라 적 레벨을 플레이어 레벨 대비 +0/+1/+2 만큼 보정합니다.  
-- **버프 시스템**  
-  AI 응답의 `buffs` 배열을 적용해 HP·힘·민첩·체력 등 스탯을 상승시킵니다.  
+- **버프 시스템**
+  AI 응답의 `buffs` 배열을 적용해 HP·힘·민첩·체력 등 스탯을 상승시킵니다.
+- **클래스/종족 반영 스토리**
+  5e-srd API로 불러온 클래스와 종족 선택을 스토리에 반영합니다.
 - **이어하기(History) 기능**  
   Zustand + localStorage로 선택/스토리 기록을 저장해 페이지 새로고침 후에도 복원합니다.  
 - **반응형 UI**  
@@ -55,10 +57,12 @@
    프로젝트 루트에 `.env.local` 파일 생성 후:
    ```env
    NEXT_PUBLIC_OPENAI_API_KEY=your_openai_api_key
-   NEXT_PUBLIC_GEMINI_API_KEY=your_gemini_api_key
+   GEMINI_API_KEY=your_gemini_api_key
    ```
 
-4. 개발 서버 실행  
+4. 5e-srd API 사용: 별도 키 없이 인터넷 연결만으로 D&D 데이터(종족, 클래스)를 불러옵니다.
+
+5. 개발 서버 실행
    ```bash
    npm run dev
    # or
@@ -66,7 +70,7 @@
    ```
    `http://localhost:3000` 에서 확인
 
-5. 프로덕션 빌드 & 실행  
+6. 프로덕션 빌드 & 실행
    ```bash
    npm run build
    npm run start

--- a/__tests__/srdRoutes.test.ts
+++ b/__tests__/srdRoutes.test.ts
@@ -1,0 +1,27 @@
+import handlerRaces from '../pages/api/races';
+import handlerClasses from '../pages/api/classes';
+import { getRaces, getClasses } from '../lib/srd';
+
+jest.mock('../lib/srd');
+
+describe('SRD API routes', () => {
+  it('returns races', async () => {
+    (getRaces as jest.Mock).mockResolvedValue(['Human']);
+    const req = {} as any;
+    const json = jest.fn();
+    const res = { status: jest.fn(() => ({ json })) } as any;
+    await handlerRaces(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(json).toHaveBeenCalledWith(['Human']);
+  });
+
+  it('returns classes', async () => {
+    (getClasses as jest.Mock).mockResolvedValue(['Wizard']);
+    const req = {} as any;
+    const json = jest.fn();
+    const res = { status: jest.fn(() => ({ json })) } as any;
+    await handlerClasses(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(json).toHaveBeenCalledWith(['Wizard']);
+  });
+});

--- a/lib/srd.ts
+++ b/lib/srd.ts
@@ -1,0 +1,25 @@
+export interface ListItem {
+  index: string;
+  name: string;
+  url: string;
+}
+
+const BASE_URL = 'https://www.dnd5eapi.co/api';
+
+export async function getRaces(): Promise<string[]> {
+  const res = await fetch(`${BASE_URL}/races`);
+  if (!res.ok) {
+    throw new Error(`SRD API error: ${res.status}`);
+  }
+  const data = await res.json();
+  return (data.results as ListItem[]).map((r) => r.name);
+}
+
+export async function getClasses(): Promise<string[]> {
+  const res = await fetch(`${BASE_URL}/classes`);
+  if (!res.ok) {
+    throw new Error(`SRD API error: ${res.status}`);
+  }
+  const data = await res.json();
+  return (data.results as ListItem[]).map((c) => c.name);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@google/genai": "^0.13.0",
         "@vercel/analytics": "^1.5.0",
         "next": "15.3.2",
-        "node-fetch": "^3.3.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "zustand": "^5.0.4"
@@ -3740,26 +3739,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/gaxios/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/gcp-metadata": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
@@ -5294,24 +5273,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-releases": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@google/genai": "^0.13.0",
     "@vercel/analytics": "^1.5.0",
     "next": "15.3.2",
-    "node-fetch": "^3.3.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "zustand": "^5.0.4"

--- a/pages/api/classes.ts
+++ b/pages/api/classes.ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getClasses } from '@/lib/srd';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<string[]>
+) {
+  try {
+    const classes = await getClasses();
+    res.status(200).json(classes);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.status(500).json([msg]);
+  }
+}

--- a/pages/api/races.ts
+++ b/pages/api/races.ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getRaces } from '@/lib/srd';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<string[]>
+) {
+  try {
+    const races = await getRaces();
+    res.status(200).json(races);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.status(500).json([msg]);
+  }
+}

--- a/pages/api/story.ts
+++ b/pages/api/story.ts
@@ -7,6 +7,8 @@ interface ReqBody {
   history: string[]
   choice: string
   combatResult: string
+  race?: string
+  className?: string
 }
 interface ResBody {
   story?: string
@@ -22,11 +24,13 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<ResBody>
 ) {
-  const { background, history, choice,combatResult } = req.body as ReqBody
+  const { background, history, choice, combatResult, race, className } =
+    req.body as ReqBody
 
+  const characterLine = race && className ? `캐릭터는 ${race} ${className}입니다.` : ''
   const basePrompt = background?.trim()
-    ? `${background.trim()}\n\n이전 대화:\n${history.join('\n')}`
-    : `이전 대화:\n${history.join('\n')}`
+    ? `${background.trim()}\n${characterLine}\n\n이전 대화:\n${history.join('\n')}`
+    : `${characterLine}\n이전 대화:\n${history.join('\n')}`
   const combatLine = combatResult
    ? `전투 결과: ${combatResult}\n`
    : "";

--- a/stores/useStoryStore.ts
+++ b/stores/useStoryStore.ts
@@ -12,6 +12,8 @@ interface StoryState {
   buffs: Record<string, number>;
   story: string;
   choices: string[];
+  race: string;
+  className: string;
   dangerLevel: string
   setDangerLevel: (dl: string) => void
   setStory: (s: string) => void;
@@ -23,6 +25,8 @@ interface StoryState {
   setPlayerHp: (hp: number) => void;
   setPlayerLevel: (level: number) => void;
   setBuffs: (buffs: Record<string, number>) => void;
+  setRace: (race: string) => void;
+  setClassName: (cls: string) => void;
 }
 
 export const useStoryStore = create<StoryState>()(
@@ -42,9 +46,11 @@ export const useStoryStore = create<StoryState>()(
         dexterity: 0,
         constitution: 0,
       },
+      race: '',
+      className: '',
       story: "",
       choices: [],
-      dangerLevel: '', 
+      dangerLevel: '',
       setDangerLevel: (dl) => set({ dangerLevel: dl }),
       setStory: (s) => set({ story: s }),
       setChoices: (c) => set({ choices: c }),
@@ -59,6 +65,8 @@ export const useStoryStore = create<StoryState>()(
       setPlayerHp: (hp) => set({ playerHp: hp }),
       setPlayerLevel: (level) => set({ playerLevel: level }),
       setBuffs: (buffs) => set({ buffs }),
+      setRace: (race) => set({ race }),
+      setClassName: (cls) => set({ className: cls }),
     }),
     {
       name: "story-store",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+    './app/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- fix README to document `GEMINI_API_KEY`
- add Tailwind config
- check API errors when fetching stories
- integrate 5e-srd API with helper module and Next.js routes
- load race and class options in character creator
- extend Zustand store to hold race and class
- remove unused `node-fetch`
- add tests for new API routes
- include race and class details in story prompts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ceba0ac3483259df37c52c4e7c57d